### PR TITLE
avoid no-catchall stage1<->stage2 race condition, thanks Laurent

### DIFF
--- a/builder/build-latest
+++ b/builder/build-latest
@@ -95,10 +95,10 @@ for output in "${outputs[@]}"; do
     mkdir -p $overlaydstpath/etc/{cont-init.d,fix-attrs.d,services.d}
     mkdir -p $overlaydstpath/var/log/s6-uncaught-logs
 
-    # create event directory in fdholder, its needed for no-catchall
+    # create "supervise" directory in fdholder, its needed for no-catchall
     # stage2 wake up
-    mkdir -p $overlaydstpath/etc/s6/services/s6-fdholderd/event
-    chmod 3730 $overlaydstpath/etc/s6/services/s6-fdholderd/event
+    mkdir -p $overlaydstpath/etc/s6/services/s6-fdholderd/supervise
+    chmod 0700 $overlaydstpath/etc/s6/services/s6-fdholderd/supervise
 
     # fix fix-attrs perms
     chmod 0755 $overlaydstpath/usr/bin/fix-attrs

--- a/builder/overlay-rootfs/etc/s6/init-no-catchall/init-stage1
+++ b/builder/overlay-rootfs/etc/s6/init-no-catchall/init-stage1
@@ -10,21 +10,21 @@ if { s6-rmrf /var/run/s6/services/s6-svscan-log }
 
 
 ##
+## ensure our vital fifo exists
+##
+
+if { s6-mkfifo -m 0600 /var/run/s6/services/s6-fdholderd/supervise/control }
+
+
+##
 ## fork the "init-stage2" script
 ##
 
 background
 {
   # block until the supervision tree is running
-  # NOTE: start waiting as soon as possible because we can get
-  # into a race condition if "s" was already sent before we
-  # started listening to the fifodir.
-  if
-  {
-    # keep stderr open, but avoid "s" printing to the outside
-    redirfd -w 1 /dev/null
-    s6-ftrig-wait /var/run/s6/services/s6-fdholderd/event "s"
-  }
+  redirfd -w 3 /var/run/s6/services/s6-fdholderd/supervise/control
+  fdclose 3
 
   # add some environment
   s6-envdir -- /etc/s6/init/env-stage2
@@ -33,6 +33,7 @@ background
   /etc/s6/init-no-catchall/init-stage2 $@
 }
 unexport !
+
 
 ##
 ## run the rest of stage 1 with sanitized descriptors


### PR DESCRIPTION
Laurent dixit :-)

```
Since s6-supervise doesn't tell the status file when it has
started, we can't use the same mechanisms to avoid race
conditions as we do to check if the service is up and down -
there's no "status of the supervise process" file.

OK, let's do it another way.

In the overlay, instead of creating the "event" subdirectory for
s6-fdholderd, create the "supervise" subdirectory with rights 0700.

At run time, before forking, run

if { s6-mkfifo -m 0600 /var/run/s6/s6-fdholderd/supervise/control }

and in the background block, run

redirfd -w 3 /var/run/s6/s6-fdholderd/supervise/control
fdclose 3

This will correctly block until s6-supervise has started.
It's a hack because it relies on an internal mechanism of s6-supervise
(we are not supposed to know that s6-supervise opens the
"supervise/control" fifo for reading), but it will work without a
race condition.

It's the same fifo trick as in the s6-svscan-log case : we will
block on a fifo until something opens it for reading. (Here, the process
that will open it for reading is s6-supervise.) And we close the fifo
afterwards because we have no other use for it and we really shouldn't
be messing with it. (Only s6-svc writes stuff to the s6-supervise fifos.)
```