### PR TITLE
bug fix & make S6_LOGGING behaviour consistent

### DIFF
--- a/builder/overlay-rootfs/etc/s6/init/init-stage1
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage1
@@ -26,6 +26,6 @@
 import-from-envdir -u -D 0 /var/run/s6/container_environment S6_LOGGING
 ifelse { s6-test ${S6_LOGGING} -ne 0 }
 {
-  /etc/s6/init-no-catchall/init-stage1 $@
+  /etc/s6/init-catchall/init-stage1 $@
 }
-/etc/s6/init-catchall/init-stage1 $@
+/etc/s6/init-no-catchall/init-stage1 $@

--- a/builder/overlay-rootfs/etc/s6/init/init-stage2
+++ b/builder/overlay-rootfs/etc/s6/init/init-stage2
@@ -48,7 +48,7 @@ foreground
         forstdin -o 0 -0 -- i
         import -u i
         if { s6-echo -- "[cont-init.d] ${i}: executing... " }
-        foreground { with-contenv /etc/cont-init.d/${i} }
+        foreground { /etc/cont-init.d/${i} }
         import -u ?
         if { s6-echo -- "[cont-init.d] ${i}: exited ${?}." }
         ifelse { s6-test ${S6_BEHAVIOUR_IF_STAGE2_FAILS} -eq 0 } { exit 0 }


### PR DESCRIPTION
* S6_LOGGING behaviour wasn't consistent in two code paths
* by default, keep init.d script env vars clean, don't import cont. envs